### PR TITLE
Enabling compression for all input files

### DIFF
--- a/modules/margin/src/main/java/com/opengamma/sdk/margin/PortfolioDataFile.java
+++ b/modules/margin/src/main/java/com/opengamma/sdk/margin/PortfolioDataFile.java
@@ -54,7 +54,6 @@ public final class PortfolioDataFile implements ImmutableBean {
   private final String data;
 
   //-------------------------------------------------------------------------
-
   /**
    * Obtains an instance from the String representation of the data.
    * <p>

--- a/modules/margin/src/test/java/com/opengamma/sdk/margin/PortfolioDataFileTest.java
+++ b/modules/margin/src/test/java/com/opengamma/sdk/margin/PortfolioDataFileTest.java
@@ -30,8 +30,8 @@ public class PortfolioDataFileTest {
 
   public void test_ofString_small() {
     PortfolioDataFile test = PortfolioDataFile.of("name.txt", "a=b");
-    assertEquals(test.getName(), "name.txt");
-    assertEquals(test.getData(), "a=b");
+    assertEquals(test.getName(), "name.txt.gz.base64");
+    assertEquals(test.getData(), "H4sIAAAAAAAAAEu0TQIAzzAAfwMAAAA=");
   }
 
   public void test_ofString_large() {


### PR DESCRIPTION
Making all 3 factory methods in PortfolioDataFile compress the input data. The compression will always take place, regardless of the size of the input data.

Also, slightly refactored the code (grouped similar methods together).

Fixed #11