### PR TITLE
TASK: Fix MarginDetailSerializer, ensure it works for all LCH variants.

### DIFF
--- a/modules/margin/src/main/java/com/opengamma/sdk/margin/MarginDetailDeserializer.java
+++ b/modules/margin/src/main/java/com/opengamma/sdk/margin/MarginDetailDeserializer.java
@@ -17,6 +17,8 @@ import org.joda.beans.ser.SerDeserializerProvider;
  */
 final class MarginDetailDeserializer extends DefaultDeserializer implements SerDeserializerProvider {
 
+  private static final String LCH = "LCH";
+  
   /**
    * The type of the detail.
    */
@@ -24,7 +26,8 @@ final class MarginDetailDeserializer extends DefaultDeserializer implements SerD
 
   // converts a CCP to a deserializer instance
   static Optional<MarginDetailDeserializer> of(Ccp ccp) {
-    if (ccp == Ccp.LCH) {
+    if (ccp.name().contains(LCH)) {
+      // Any LCH variants use the LCH Margin Detail deserializer
       return Optional.of(new MarginDetailDeserializer(LchMarginDetail.meta()));
     } else {
       return Optional.empty();

--- a/modules/margin/src/test/java/com/opengamma/sdk/margin/MarginDetailDeserializerTest.java
+++ b/modules/margin/src/test/java/com/opengamma/sdk/margin/MarginDetailDeserializerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.sdk.margin;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link MarginDetailDeserializer}.
+ */
+public class MarginDetailDeserializerTest {
+
+  @Test
+  public void testSupportedCcp() {
+    assertTrue(MarginDetailDeserializer.of(Ccp.LCH).isPresent());
+    assertTrue(MarginDetailDeserializer.of(Ccp.of("LCH_TEST")).isPresent());
+  }
+
+  @Test
+  public void testUnsupportedCcp() {
+    assertFalse(MarginDetailDeserializer.of(Ccp.EUREX).isPresent());
+    assertFalse(MarginDetailDeserializer.of(Ccp.of("UNKNOWN")).isPresent());
+  }
+}


### PR DESCRIPTION
Currently broken for even main LCH CCP due to CCP no longer being an enum.