### PR TITLE
Close response in interceptor

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma</groupId>
     <artifactId>corporate-parent</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <relativePath />
   </parent>
   <groupId>com.opengamma.sdk</groupId>
@@ -14,6 +14,38 @@
   <packaging>jar</packaging>
   <name>SDK-Examples</name>
   <description>OpenGamma SDK - Example code to demonstrate usage</description>
+
+  <!-- ==================================================================== -->
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.joda</groupId>
+                    <artifactId>joda-beans-maven-plugin</artifactId>
+                    <versionRange>[1.1,)</versionRange>
+                    <goals>
+                      <goal>generate-no-resolve</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
   <!-- ==================================================================== -->
   <dependencies>
@@ -39,6 +71,7 @@
     <!-- Properties for joda-beans-maven-plugin -->
     <!-- Lock in JDK config (not Guava) and stick with older version -->
     <joda-beans-maven-plugin.version>1.1</joda-beans-maven-plugin.version>
+    <joda.beans.version>2.8.0</joda.beans.version>
     <joda.beans.config>jdk</joda.beans.config>
     <!-- Not installed/deployed -->
     <maven.install.skip>true</maven.install.skip>

--- a/modules/common/src/test/java/com/opengamma/sdk/common/BasicTest.java
+++ b/modules/common/src/test/java/com/opengamma/sdk/common/BasicTest.java
@@ -39,7 +39,7 @@ public class BasicTest {
         .authClientFactory(inv -> mockAuth)
         .build();
     assertThat(invoker.getServiceUrl()).isEqualTo(SERVICE_URL);
-    assertThat(invoker.getHttpClient().interceptors()).hasSize(4);
+    assertThat(invoker.getHttpClient().interceptors()).hasSize(3);
     assertThat(invoker.getHttpClient().followRedirects()).isTrue();
     assertThat(invoker.getExecutor().isShutdown()).isFalse();
     invoker.close();
@@ -55,7 +55,7 @@ public class BasicTest {
         .authClientFactory(inv -> mockAuth)
         .build()) {
       assertThat(invoker.getServiceUrl()).isEqualTo(SERVICE_URL);
-      assertThat(invoker.getHttpClient().interceptors()).hasSize(5);  // logging, user-agent & auth& retry plus one from test
+      assertThat(invoker.getHttpClient().interceptors()).hasSize(4);  // logging, user-agent & auth plus one from test
       assertThat(invoker.getHttpClient().followRedirects()).isFalse();
     }
   }
@@ -68,7 +68,7 @@ public class BasicTest {
         .authClientFactory(inv -> mockAuth)
         .build()) {
       assertThat(invoker.getServiceUrl()).isEqualTo(SERVICE_URL);
-      assertThat(invoker.getHttpClient().interceptors()).hasSize(3);  // user-agent & auth & retry
+      assertThat(invoker.getHttpClient().interceptors()).hasSize(2);  // user-agent & auth
     }
   }
 
@@ -80,7 +80,8 @@ public class BasicTest {
           .url(serviceInvoker.getServiceUrl().resolve("/test"))
           .get()
           .build();
-      assertThatExceptionOfType(AuthenticationException.class).isThrownBy(() -> serviceInvoker.getHttpClient().newCall(testRequest).execute());
+      assertThatExceptionOfType(AuthenticationException.class)
+          .isThrownBy(() -> serviceInvoker.getHttpClient().newCall(testRequest).execute());
     }
   }
 

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -153,6 +153,34 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.joda</groupId>
+                    <artifactId>joda-beans-maven-plugin</artifactId>
+                    <versionRange>[1.1,)</versionRange>
+                    <goals>
+                      <goal>generate-no-resolve</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <!-- ==================================================================== -->


### PR DESCRIPTION
OkHttp has changed to throw an exception if a chain.proceed()
is called a second time without closing the first response

Also change the retry behaviour to be opt-in. Looks like it didn't work unless set to 2 previously anyway